### PR TITLE
Update usb_intf.c

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -305,6 +305,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2357, 0x010F),.driver_info = RTL8812}, /* TP-Link - T4UHP */
 	{USB_DEVICE(0x2357, 0x0122),.driver_info = RTL8812}, /* TP-Link - T4UHP (other) */
 	{USB_DEVICE(0x148F, 0x9097),.driver_info = RTL8812}, /* Amped Wireless ACA1 */
+	{USB_DEVICE(0x0411, 0x025D),.driver_info = RTL8812}, /* BUFFALO - WI-U3-866D */
 #endif
 
 #ifdef CONFIG_RTL8821A
@@ -326,7 +327,6 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x0846, 0x9052),.driver_info = RTL8821}, /* Netgear - A6100 */
 	{USB_DEVICE(0x2019, 0xAB32),.driver_info = RTL8821}, /* Planex - GW-450S */
 	{USB_DEVICE(0x0411, 0x0242),.driver_info = RTL8821}, /* BUFFALO - Edimax */
-	{USB_DEVICE(0x0411, 0x025D),.driver_info = RTL8821}, /* BUFFALO - WI-U3-866D */
 	{USB_DEVICE(0x0411, 0x029B),.driver_info = RTL8821}, /* BUFFALO - WI-U2-433DHP */
 	{USB_DEVICE(0x056E, 0x4007),.driver_info = RTL8821}, /* ELECOM - WDC-433DU2H */
 	{USB_DEVICE(0x056E, 0x400E),.driver_info = RTL8821}, /* ELECOM - WDC-433SU2M2 */


### PR DESCRIPTION
Buffalo product WI-U3-866D has chipset 8812AU not 8821.
So that,
in os_dep/linux/usb_inf.c,
Line 329
{USB_DEVICE(0x0411, 0x025D),.driver_info = RTL8821}, /* BUFFALO - WI-U3-866D */
should be deleted, and then insert
following line
{USB_DEVICE(0x0411, 0x025D),.driver_info = RTL8812}, /* BUFFALO - WI-U3-866D */
after line 307.