### PR TITLE
fix build up to kernel v6.1rc1

### DIFF
--- a/hal/hal_hci/hal_usb.c
+++ b/hal/hal_hci/hal_usb.c
@@ -35,7 +35,7 @@ int	usb_init_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 
 #ifdef PLATFORM_LINUX
 	tasklet_init(&precvpriv->recv_tasklet,
-	             (void(*)(unsigned long))usb_recv_tasklet,
+	             usb_recv_tasklet,
 	             (unsigned long)padapter);
 #endif /* PLATFORM_LINUX */
 

--- a/hal/rtl8812a/usb/rtl8812au_xmit.c
+++ b/hal/rtl8812a/usb/rtl8812au_xmit.c
@@ -30,7 +30,7 @@ s32	rtl8812au_init_xmit_priv(_adapter *padapter)
 
 #ifdef PLATFORM_LINUX
 	tasklet_init(&pxmitpriv->xmit_tasklet,
-	             (void(*)(unsigned long))rtl8812au_xmit_tasklet,
+	             rtl8812au_xmit_tasklet,
 	             (unsigned long)padapter);
 #endif
 #ifdef CONFIG_TX_EARLY_MODE

--- a/hal/rtl8812a/usb/usb_ops_linux.c
+++ b/hal/rtl8812a/usb/usb_ops_linux.c
@@ -475,7 +475,7 @@ _exit_recvbuf2recvframe:
 }
 
 
-void rtl8812au_xmit_tasklet(void *priv)
+void rtl8812au_xmit_tasklet(unsigned long priv)
 {
 	int ret = _FALSE;
 	_adapter *padapter = (_adapter*)priv;

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -163,7 +163,11 @@ typedef void*		_thread_hdl_;
 typedef int		thread_return;
 typedef void*	thread_context;
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5,17,0))
+#define thread_exit() kthread_complete_and_exit(NULL, 0)
+#else
 #define thread_exit() complete_and_exit(NULL, 0)
+#endif
 
 typedef void timer_hdl_return;
 typedef void* timer_hdl_context;

--- a/include/rtl8812a_xmit.h
+++ b/include/rtl8812a_xmit.h
@@ -331,7 +331,7 @@ s32 rtl8812au_hal_xmit(PADAPTER padapter, struct xmit_frame *pxmitframe);
 s32 rtl8812au_mgnt_xmit(PADAPTER padapter, struct xmit_frame *pmgntframe);
 s32	 rtl8812au_hal_xmitframe_enqueue(_adapter *padapter, struct xmit_frame *pxmitframe);
 s32 rtl8812au_xmit_buf_handler(PADAPTER padapter);
-void rtl8812au_xmit_tasklet(void *priv);
+void rtl8812au_xmit_tasklet(unsigned long priv);
 s32 rtl8812au_xmitframe_complete(_adapter *padapter, struct xmit_priv *pxmitpriv, struct xmit_buf *pxmitbuf);
 #endif
 

--- a/include/usb_ops_linux.h
+++ b/include/usb_ops_linux.h
@@ -78,7 +78,7 @@ int usb_write16(struct intf_hdl *pintfhdl, u32 addr, u16 val);
 int usb_write32(struct intf_hdl *pintfhdl, u32 addr, u32 val);
 int usb_writeN(struct intf_hdl *pintfhdl, u32 addr, u32 length, u8 *pdata);
 u32 usb_read_port(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem);
-void usb_recv_tasklet(void *priv);
+void usb_recv_tasklet(unsigned long data);
 
 #endif
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -797,9 +797,14 @@ check_bss:
 #endif
 
 		DBG_871X(FUNC_ADPT_FMT" call cfg80211_roamed\n", FUNC_ADPT_ARG(padapter));
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
+		roam_info.links[0].channel = notify_channel;
+		roam_info.links[0].bssid = cur_network->network.MacAddress;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 		roam_info.channel = notify_channel;
 		roam_info.bssid = cur_network->network.MacAddress;
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 		roam_info.req_ie = pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2;
 		roam_info.req_ie_len = pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2;
 		roam_info.resp_ie = pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6;
@@ -1388,7 +1393,9 @@ exit:
 }
 
 static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
+                                int link_id, u8 key_index, bool pairwise, const u8 *mac_addr,
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
                                 u8 key_index, bool pairwise, const u8 *mac_addr,
 #else	// (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37))
                                 u8 key_index, const u8 *mac_addr,
@@ -1528,7 +1535,9 @@ addkey_end:
 }
 
 static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
+                                int link_id, u8 key_index, bool pairwise, const u8 *mac_addr,
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
                                 u8 key_index, bool pairwise, const u8 *mac_addr,
 #else	// (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37))
                                 u8 key_index, const u8 *mac_addr,
@@ -1561,7 +1570,9 @@ static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev,
 }
 
 static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
+                                int link_id, u8 key_index, bool pairwise, const u8 *mac_addr)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
                                 u8 key_index, bool pairwise, const u8 *mac_addr)
 #else	// (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37))
                                 u8 key_index, const u8 *mac_addr)
@@ -1581,7 +1592,11 @@ static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev,
 }
 
 static int cfg80211_rtw_set_default_key(struct wiphy *wiphy,
-                                        struct net_device *ndev, u8 key_index
+					struct net_device *ndev,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
+                                        int link_id,
+#endif
+                                        u8 key_index
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,38)) || defined(COMPAT_KERNEL_RELEASE)
                                         , bool unicast, bool multicast
 #endif
@@ -4019,7 +4034,11 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0))
+static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev, unsigned int link_id)
+#else
 static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev)
+#endif
 {
 	DBG_871X(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 	return 0;

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -564,8 +564,11 @@ int hostapd_mode_init(_adapter *padapter)
 	mac[4]=0x11;
 	mac[5]=0x12;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0))
+       eth_hw_addr_set(pnetdev, mac);
+#else
 	_rtw_memcpy(pnetdev->dev_addr, mac, ETH_ALEN);
-
+#endif
 
 	netif_carrier_off(pnetdev);
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -627,7 +627,11 @@ static int rtw_net_set_mac_address(struct net_device *pnetdev, void *p)
 		//DBG_871X("r8711_net_set_mac_address(), MAC=%x:%x:%x:%x:%x:%x\n", addr->sa_data[0], addr->sa_data[1], addr->sa_data[2], addr->sa_data[3],
 		//addr->sa_data[4], addr->sa_data[5]);
 		_rtw_memcpy(padapter->eeprompriv.mac_addr, addr->sa_data, ETH_ALEN);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0))
+		//eth_hw_addr_set(pnetdev, addr->sa_data);
+#else
 		//_rtw_memcpy(pnetdev->dev_addr, addr->sa_data, ETH_ALEN);
+#endif
 		//padapter->bset_hwaddr = _TRUE;
 	}
 
@@ -1885,7 +1889,11 @@ int _netdev_if2_open(struct net_device *pnetdev)
 
 		_rtw_memcpy(padapter->eeprompriv.mac_addr, mac, ETH_ALEN);
 		rtw_init_wifidirect_addrs(padapter, padapter->eeprompriv.mac_addr, padapter->eeprompriv.mac_addr);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0))
+		eth_hw_addr_set(pnetdev, padapter->eeprompriv.mac_addr);
+#else
 		_rtw_memcpy(pnetdev->dev_addr, padapter->eeprompriv.mac_addr, ETH_ALEN);
+#endif
 	}
 #endif //CONFIG_PLATFORM_INTEL_BYT
 
@@ -2254,7 +2262,11 @@ static int _rtw_drv_register_netdev(_adapter *padapter, char *name)
 	/* alloc netdev name */
 	rtw_init_netdev_name(pnetdev, name);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0))
+	eth_hw_addr_set(pnetdev, padapter->eeprompriv.mac_addr);
+#else
 	_rtw_memcpy(pnetdev->dev_addr, padapter->eeprompriv.mac_addr, ETH_ALEN);
+#endif
 
 	/* Tell the network stack we exist */
 	if (register_netdev(pnetdev) != 0) {
@@ -2334,7 +2346,11 @@ int _netdev_open(struct net_device *pnetdev)
 #ifdef CONFIG_PLATFORM_INTEL_BYT
 		rtw_macaddr_cfg(padapter->eeprompriv.mac_addr);
 		rtw_init_wifidirect_addrs(padapter, padapter->eeprompriv.mac_addr, padapter->eeprompriv.mac_addr);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0))
+		eth_hw_addr_set(pnetdev, padapter->eeprompriv.mac_addr);
+#else
 		_rtw_memcpy(pnetdev->dev_addr, padapter->eeprompriv.mac_addr, ETH_ALEN);
+#endif
 #endif //CONFIG_PLATFORM_INTEL_BYT
 
 		padapter->bDriverStopped = _FALSE;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -37,7 +37,9 @@ inline struct proc_dir_entry *get_rtw_drv_proc(void)
 #define file_inode(file) ((file)->f_dentry->d_inode)
 #endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
+#define PDE_DATA pde_data
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0))
 #define PDE_DATA(inode) PDE((inode))->data
 #define proc_get_parent_data(inode) PDE((inode))->parent->data
 #endif

--- a/os_dep/linux/usb_ops_linux.c
+++ b/os_dep/linux/usb_ops_linux.c
@@ -717,7 +717,7 @@ void usb_init_recvbuf(_adapter *padapter, struct recv_buf *precvbuf)
 int recvbuf2recvframe(PADAPTER padapter, void *ptr);
 
 #ifdef CONFIG_USE_USB_BUFFER_ALLOC_RX
-void usb_recv_tasklet(void *priv)
+void usb_recv_tasklet(unsigned long priv)
 {
 	struct recv_buf *precvbuf = NULL;
 	_adapter	*padapter = (_adapter*)priv;
@@ -870,7 +870,7 @@ u32 usb_read_port(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem)
 }
 #else	// CONFIG_USE_USB_BUFFER_ALLOC_RX
 
-void usb_recv_tasklet(void *priv)
+void usb_recv_tasklet(unsigned long priv)
 {
 	_pkt			*pskb;
 	_adapter		*padapter = (_adapter*)priv;

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2209,7 +2209,11 @@ int rtw_change_ifname(_adapter *padapter, const char *ifname)
 
 	rtw_init_netdev_name(pnetdev, ifname);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0))
+	eth_hw_addr_set(pnetdev, padapter->eeprompriv.mac_addr);
+#else
 	_rtw_memcpy(pnetdev->dev_addr, padapter->eeprompriv.mac_addr, ETH_ALEN);
+#endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,26))
 	if(!rtnl_is_locked())

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2339,7 +2339,9 @@ u64 rtw_division64(u64 x, u64 y)
 inline u32 rtw_random32(void)
 {
 #ifdef PLATFORM_LINUX
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))
+	return get_random_u32();
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0))
 	return prandom_u32();
 #elif (LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,18))
 	u32 random_int;


### PR DESCRIPTION
Hi,

I ran into some compile errors testing a WIP openwrt 6.1r1 ALL_KMODS build with this package.

I tried to find & point out the kernel change responsible in each commit message.
Some of them may be very wrong.

Compile tested only (aarch64 kernel v6.1rc1), and I do not have hardware to test with, sorry.

Cheers